### PR TITLE
Use crate_name rather than project-name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use libfalcon::{cli::run, error::Error, Runner, unit::gb};
 #[tokio::main]
 async fn main() -> Result<(), Error> {
 
-    let mut d = Runner::new("{{project-name}}");
+    let mut d = Runner::new("{{crate_name}}");
 
     // nodes
     let violin = d.node("violin", "helios-1.3", 4, gb(4));


### PR DESCRIPTION
The argument doesn't support hyphens, so e.g. `falcon-bootstrap` doesn't work. `crate_name` replaces hyphens with underscores, so in this case it would be `falcon_bootstrap` which works.